### PR TITLE
feat: provide an option to select chrome binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ snap-tweet https://twitter.com/TwitterJP/status/578707432 --locale ja
   <em>Using the Japanese locale (ja)</em>
 </p>
 
+### Custom path for Chrome binary
+You can specify the path for the Chrome binary if it is not autodetected or you want to use another binary.
+```sh
+snap-tweet https://twitter.com/TwitterJP/status/578707432 --chrome-path /usr/bin/chrome
+```
+
 ### Show Thread
 Use the `--show-thread` flag to include the parent tweet in the screenshot.
 
@@ -124,6 +130,7 @@ Options:
   -t, --show-thread        Show tweet thread
   -d, --dark-mode          Show tweet in dark mode
   -l, --locale <locale>    Locale (default: en)
+  -c, --chrome-path <path> Full path of the Chrome binary to use
   -h, --help               Display this message
   -v, --version            Display version number
 ```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,6 +38,13 @@ const cli = cac('snap-tweet')
 			default: 'en',
 		},
 	)
+	.option(
+		'-c, --chrome-path <path>',
+		'Manually provide chrome path',
+		{
+			default: undefined,
+		},
+	)
 	.help()
 	.version(version)
 	.example('$ snap-tweet https://twitter.com/jack/status/20')
@@ -69,7 +76,7 @@ const cli = cac('snap-tweet')
 		process.exit(0);
 	}
 
-	const tweetCamera = new TweetCamera();
+	const tweetCamera = new TweetCamera(options.chromePath);
 	const startTask = renderTaskRunner();
 
 	await Promise.all(tweets.map(async ({

--- a/src/tweet-camera.ts
+++ b/src/tweet-camera.ts
@@ -65,16 +65,18 @@ class TweetCamera {
 
 	initializingChrome: Promise<any>;
 
-	constructor() {
-		this.initializingChrome = this.initializeChrome();
+	constructor(chromePath: string) {
+		this.initializingChrome = this.initializeChrome(chromePath);
 	}
 
-	async initializeChrome() {
+	async initializeChrome(chromePath: string) {
+		const pathOption = chromePath === undefined ? {} : { chromePath };
 		const chrome = await launch({
 			chromeFlags: [
 				'--headless',
 				'--disable-gpu',
 			],
+			...pathOption,
 		});
 
 		exitHook(() => {


### PR DESCRIPTION
Sometimes the chrome binary cannot be found automagically by the the chrome library. This patch allows an user to manually select it. I tried to follow closely the style of the source & linted.