### PR TITLE
fix: #27 , selectively ignore missing copy button

### DIFF
--- a/src/tweet-camera.ts
+++ b/src/tweet-camera.ts
@@ -157,21 +157,11 @@ class TweetCamera {
 		const tweetContainerNodeId = await querySelector(client.DOM, root.nodeId, '#app > div > div > div:last-child');
 
 		// "Copy link to Tweet" button
-		const hideCopyLinkButton = querySelector(client.DOM, tweetContainerNodeId, '[role="button"]')
-			.then(d => hideNode(
-				client.DOM,
-				d,
-			)).catch((error) => {
-				if (String(error) === 'Error: Selector "[role="button"]" not found') {
-					// ignore
-					return;
-				}
-				throw error;
-			});
+		const hideCopyLinkButtonNodeId = await querySelector(client.DOM, tweetContainerNodeId, '[role="button"]').catch(() => null);
 
 		await Promise.all([
 			// "Copy link to Tweet" button
-			hideCopyLinkButton,
+			(hideCopyLinkButtonNodeId && hideNode(client.DOM, hideCopyLinkButtonNodeId)),
 
 			// Info button - can't use aria-label because of i18n
 			hideNode(

--- a/src/tweet-camera.ts
+++ b/src/tweet-camera.ts
@@ -156,12 +156,22 @@ class TweetCamera {
 		const { root } = await client.DOM.getDocument();
 		const tweetContainerNodeId = await querySelector(client.DOM, root.nodeId, '#app > div > div > div:last-child');
 
+		// "Copy link to Tweet" button
+		const hideCopyLinkButton = querySelector(client.DOM, tweetContainerNodeId, '[role="button"]')
+			.then(d => hideNode(
+				client.DOM,
+				d,
+			)).catch((error) => {
+				if (String(error) === 'Error: Selector "[role="button"]" not found') {
+					// ignore
+					return;
+				}
+				throw error;
+			});
+
 		await Promise.all([
 			// "Copy link to Tweet" button
-			hideNode(
-				client.DOM,
-				await querySelector(client.DOM, tweetContainerNodeId, '[role="button"]'),
-			),
+			hideCopyLinkButton,
 
 			// Info button - can't use aria-label because of i18n
 			hideNode(


### PR DESCRIPTION
In some versions of the generated embed , the copy link button isn't shown 
and it stop the app from moving forward. 
The commit adds a selective error handler just for that case

Fix #27 