### PR TITLE
feat: support x.com

### DIFF
--- a/src/tweet-camera.ts
+++ b/src/tweet-camera.ts
@@ -92,7 +92,7 @@ class TweetCamera {
 
 	static parseTweetUrl(tweetUrl: string) {
 		assert(tweetUrl, 'Tweet URL must be passed in');
-		const [, username, tweetId] = tweetUrl.match(/twitter.com\/(\w{1,15})\/status\/(\d+)/) ?? [];
+		const [, username, tweetId] = tweetUrl.match(/(?:twitter\.com|x\.com)\/(\w{1,15})\/status\/(\d+)/) ?? [];
 
 		assert(
 			username && tweetId,

--- a/src/tweet-camera.ts
+++ b/src/tweet-camera.ts
@@ -92,7 +92,7 @@ class TweetCamera {
 
 	static parseTweetUrl(tweetUrl: string) {
 		assert(tweetUrl, 'Tweet URL must be passed in');
-		const [, username, tweetId] = tweetUrl.match(/(?:twitter\.com|x\.com)\/(\w{1,15})\/status\/(\d+)/) ?? [];
+		const [, username, tweetId] = tweetUrl.match(/(?:twitter|x)\.com\/(\w{1,15})\/status\/(\d+)/) ?? [];
 
 		assert(
 			username && tweetId,


### PR DESCRIPTION
As title.

Tested via

```
npm run dev -- https://twitter.com/jack/status/20
npm run dev -- https://x.com/jack/status/20
```

closes #43